### PR TITLE
fix: code refactoring and namespace/use statements.

### DIFF
--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -78,7 +78,9 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 * @since    1.0.0
 	 */
 	public function createEnrollmentClass() {
+
 		$this->openedx_enrollment = new Openedx_Woocommerce_Plugin_Enrollment( $this );
+
 	}
 
 	/**
@@ -104,11 +106,11 @@ class Openedx_Woocommerce_Plugin_Admin {
 
 	}
 
-	/**
-	 * Register the JavaScript for the admin area.
-	 *
-	 * @since    1.0.0
-	 */
+    /**
+    * Register the JavaScript for the admin area.
+    * 
+    * @since    1.0.0
+    */
 	public function enqueue_scripts() {
 
 		/**
@@ -124,6 +126,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 		 */
 
 		//wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/openedx-woocommerce-plugin-admin.js', array( 'jquery' ), $this->version, false );
+
 	}
 
 	/**
@@ -131,8 +134,10 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function register_enrollment_custom_post_type(){
+	public function register_enrollment_custom_post_type() {
+
 		$this->openedx_enrollment->register_enrollment_custom_post_type();
+
 	}
 
 	/**
@@ -140,8 +145,10 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function render_enrollment_info_form(){
+	public function render_enrollment_info_form() {
+
 		$this->openedx_enrollment_info_form = new Openedx_Woocommerce_Plugin_Enrollment_Info_Form($this->openedx_enrollment);
+
 	}
 
 	 /**
@@ -162,6 +169,7 @@ class Openedx_Woocommerce_Plugin_Admin {
         $post_type = $this->createPostType( $post_type, $plural, $single, $description, $options );
 		
         return $post_type;
+
     }
 
 	/**
@@ -175,7 +183,9 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 * @return object              Post type class object.
 	 */
 	public function createPostType($post_type = '', $plural = '', $single = '', $description = '', $options = array()) {
+		
 		return new Openedx_Woocommerce_Plugin_Post_Type( $post_type, $plural, $single, $description, $options );
+
 	}
 
 }

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -59,8 +59,8 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 *
 	 * @since    1.0.0
 	 * @param      string    $plugin_name   The name of this plugin.
-	 * @param      string    $version    	The version of this plugin.
-	 * @param      string    $test			Flag variable to know if it is a test.
+	 * @param      string    $version       The version of this plugin.
+	 * @param      string    $test          Flag variable to know if it is a test.
 	 */
 	public function __construct( $plugin_name, $version, $test = null) {
 
@@ -77,7 +77,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function createEnrollmentClass(){
+	public function createEnrollmentClass() {
 		$this->openedx_enrollment = new Openedx_Woocommerce_Plugin_Enrollment( $this );
 	}
 
@@ -153,7 +153,6 @@ class Openedx_Woocommerce_Plugin_Admin {
      * @param  string $description Description of post type.
      * @return object              Post type class object
      */
-
     public function register_post_type( $post_type = '', $plural = '', $single = '', $description = '', $options = array() ) {
 
         if ( ! $post_type || ! $plural || ! $single ) {
@@ -175,8 +174,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 * @param  array  $options     Additional options for the post type.
 	 * @return object              Post type class object.
 	 */
-
-	public function createPostType($post_type = '', $plural = '', $single = '', $description = '', $options = array()){
+	public function createPostType($post_type = '', $plural = '', $single = '', $description = '', $options = array()) {
 		return new Openedx_Woocommerce_Plugin_Post_Type( $post_type, $plural, $single, $description, $options );
 	}
 

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -107,25 +107,25 @@ class Openedx_Woocommerce_Plugin_Admin {
 	}
 
     /**
-    * Register the JavaScript for the admin area.
-    * 
-    * @since    1.0.0
-    */
+     * Register the JavaScript for the admin area.
+     * 
+     * @since    1.0.0
+     */
 	public function enqueue_scripts() {
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Openedx_Woocommerce_Plugin_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Openedx_Woocommerce_Plugin_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
+        /**
+         * This function is provided for demonstration purposes only.
+         *
+         * An instance of this class should be passed to the run() function
+         * defined in Openedx_Woocommerce_Plugin_Loader as all of the hooks are defined
+         * in that particular class.
+         *
+         * The Openedx_Woocommerce_Plugin_Loader will then create the relationship
+         * between the defined hooks and the functions defined in this
+         * class.
+         */
 
-		//wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/openedx-woocommerce-plugin-admin.js', array( 'jquery' ), $this->version, false );
+         //wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/openedx-woocommerce-plugin-admin.js', array( 'jquery' ), $this->version, false );
 
 	}
 

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace App\admin;
+use App\model\Openedx_Woocommerce_Plugin_Enrollment;
+use App\model\Openedx_Woocommerce_Plugin_Post_Type;
+use App\admin\views\Openedx_Woocommerce_Plugin_Enrollment_Info_Form;
+
 /**
  * The admin-specific functionality of the plugin.
  *

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -58,15 +58,27 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @param      string    $plugin_name       The name of this plugin.
-	 * @param      string    $version    The version of this plugin.
+	 * @param      string    $plugin_name   The name of this plugin.
+	 * @param      string    $version    	The version of this plugin.
+	 * @param      string    $test			Flag variable to know if it is a test.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_name, $version, $test = null) {
 
 		$this->plugin_name = $plugin_name;
 		$this->version = $version;
-		$this->openedx_enrollment = new Openedx_Woocommerce_Plugin_Enrollment( $this );
+		if(!$test){
+			$this->createEnrollmentClass();
+		}
+		
+	}
 
+	/**
+	 * Create an instance of the Openedx_Woocommerce_Plugin_Enrollment class.
+	 *
+	 * @since    1.0.0
+	 */
+	public function createEnrollmentClass(){
+		$this->openedx_enrollment = new Openedx_Woocommerce_Plugin_Enrollment( $this );
 	}
 
 	/**
@@ -148,9 +160,24 @@ class Openedx_Woocommerce_Plugin_Admin {
             return;
         }
 
-        $post_type = new Openedx_Woocommerce_Plugin_Post_Type( $post_type, $plural, $single, $description, $options );
-
+        $post_type = $this->createPostType( $post_type, $plural, $single, $description, $options );
+		
         return $post_type;
     }
+
+	/**
+	 * Create a new instance of the Openedx_Woocommerce_Plugin_Post_Type class and register a new post type.
+	 *
+	 * @param  string $post_type   Post type name.
+	 * @param  string $plural      Post type item plural name.
+	 * @param  string $single      Post type item single name.
+	 * @param  string $description Description of the post type.
+	 * @param  array  $options     Additional options for the post type.
+	 * @return object              Post type class object.
+	 */
+
+	public function createPostType($post_type = '', $plural = '', $single = '', $description = '', $options = array()){
+		return new Openedx_Woocommerce_Plugin_Post_Type( $post_type, $plural, $single, $description, $options );
+	}
 
 }

--- a/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\admin\views;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,11 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"App\\": ""
+			"App\\": "includes/",
+			"App\\model\\": "includes/model/",
+			"App\\admin\\": "admin/",
+			"App\\admin\\views\\": "admin/views/",
+			"App\\public\\": "public/"
 		}
 	},
 	"autoload-dev": {

--- a/includes/Openedx_Woocommerce_Plugin.php
+++ b/includes/Openedx_Woocommerce_Plugin.php
@@ -107,41 +107,41 @@ class Openedx_Woocommerce_Plugin {
 		 * The class responsible for orchestrating the actions and filters of the
 		 * core plugin.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/Openedx_Woocommerce_Plugin_Loader.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'includes/Openedx_Woocommerce_Plugin_Loader.php';
 
 		/**
 		 * The class responsible for defining internationalization functionality
 		 * of the plugin.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/Openedx_Woocommerce_Plugin_i18n.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'includes/Openedx_Woocommerce_Plugin_i18n.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/Openedx_Woocommerce_Plugin_Admin.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'admin/Openedx_Woocommerce_Plugin_Admin.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/Openedx_Woocommerce_Plugin_Public.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'public/Openedx_Woocommerce_Plugin_Public.php';
 
 		$this->loader = new Openedx_Woocommerce_Plugin_Loader();
 
 		/**
 		 * The class responsible for defining the enrollment object
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/model/Openedx_Woocommerce_Plugin_Enrollment.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'includes/model/Openedx_Woocommerce_Plugin_Enrollment.php';
 
 		/**
 		 * The class responsible for defining the custom-post-type object
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/model/Openedx_Woocommerce_Plugin_Post_Type.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'includes/model/Openedx_Woocommerce_Plugin_Post_Type.php';
 
 		/**
 		 * The class responsible for rendering the enrollment info form
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php';
+         include_once plugin_dir_path( dirname( __FILE__ )) . 'admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php';
 		
 	}
 

--- a/includes/Openedx_Woocommerce_Plugin.php
+++ b/includes/Openedx_Woocommerce_Plugin.php
@@ -142,7 +142,7 @@ class Openedx_Woocommerce_Plugin {
 		 * The class responsible for rendering the enrollment info form
 		 */
          include_once plugin_dir_path( dirname( __FILE__ )) . 'admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php';
-		
+         
 	}
 
 	/**

--- a/includes/Openedx_Woocommerce_Plugin.php
+++ b/includes/Openedx_Woocommerce_Plugin.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace App;
+use App\admin\Openedx_Woocommerce_Plugin_Admin;
+use App\public\Openedx_Woocommerce_Plugin_Public;
+
 /**
  * The file that defines the core plugin class
  *

--- a/includes/Openedx_Woocommerce_Plugin_Activator.php
+++ b/includes/Openedx_Woocommerce_Plugin_Activator.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App;
+
 /**
  * Fired during plugin activation
  *

--- a/includes/Openedx_Woocommerce_Plugin_Deactivator.php
+++ b/includes/Openedx_Woocommerce_Plugin_Deactivator.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App;
+
 /**
  * Fired during plugin deactivation
  *

--- a/includes/Openedx_Woocommerce_Plugin_Loader.php
+++ b/includes/Openedx_Woocommerce_Plugin_Loader.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App;
+
 /**
  * Register all actions and filters for the plugin
  *

--- a/includes/Openedx_Woocommerce_Plugin_i18n.php
+++ b/includes/Openedx_Woocommerce_Plugin_i18n.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App;
+
 /**
  * Define the internationalization functionality
  *

--- a/includes/model/Openedx_Woocommerce_Plugin_Enrollment.php
+++ b/includes/model/Openedx_Woocommerce_Plugin_Enrollment.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\model;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/includes/model/Openedx_Woocommerce_Plugin_Post_Type.php
+++ b/includes/model/Openedx_Woocommerce_Plugin_Post_Type.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\model;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/openedx-woocommerce-plugin.php
+++ b/openedx-woocommerce-plugin.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Openedx_Woocommerce_Plugin_Activator;
+use App\Openedx_Woocommerce_Plugin_Deactivator;
+use App\Openedx_Woocommerce_Plugin;
+
 /**
  * The plugin bootstrap file
  *

--- a/openedx-woocommerce-plugin.php
+++ b/openedx-woocommerce-plugin.php
@@ -46,8 +46,8 @@ define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '1.0.0' );
  * This action is documented in includes/class-openedx-woocommerce-plugin-activator.php
  */
 function activate_openedx_woocommerce_plugin() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/Openedx_Woocommerce_Plugin_Activator.php';
-	Openedx_Woocommerce_Plugin_Activator::activate();
+    include_once plugin_dir_path( __FILE__ ) . 'includes/Openedx_Woocommerce_Plugin_Activator.php';
+    Openedx_Woocommerce_Plugin_Activator::activate();
 }
 
 /**
@@ -55,8 +55,8 @@ function activate_openedx_woocommerce_plugin() {
  * This action is documented in includes/class-openedx-woocommerce-plugin-deactivator.php
  */
 function deactivate_openedx_woocommerce_plugin() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/Openedx_Woocommerce_Plugin_Deactivator.php';
-	Openedx_Woocommerce_Plugin_Deactivator::deactivate();
+    include_once plugin_dir_path( __FILE__) . 'includes/Openedx_Woocommerce_Plugin_Deactivator.php';
+    Openedx_Woocommerce_Plugin_Deactivator::deactivate();
 }
 
 register_activation_hook( __FILE__, 'activate_openedx_woocommerce_plugin' );
@@ -66,7 +66,7 @@ register_deactivation_hook( __FILE__, 'deactivate_openedx_woocommerce_plugin' );
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.
  */
-require plugin_dir_path( __FILE__ ) . 'includes/Openedx_Woocommerce_Plugin.php';
+require plugin_dir_path( __FILE__) . 'includes/Openedx_Woocommerce_Plugin.php';
 
 /**
  * Begins execution of the plugin.

--- a/public/Openedx_Woocommerce_Plugin_Public.php
+++ b/public/Openedx_Woocommerce_Plugin_Public.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\public;
+
 /**
  * The public-facing functionality of the plugin.
  *


### PR DESCRIPTION
## Description

A refactoring of the code was done in order to decouple the code from the Openedx_Woocommerce_Plugin_Admin file for:

- Facilitate future implementations
- Facilitate the testing process of the class.

In addition, namespace and their respective "use" were declared if necessary in each class in order to make easier and cleaner the invocation of the classes between the plugin files. It will benefit us as developers for a better understanding and improve the scalability of the code.


## Testing instructions

To test, perform the normal flow of activation and deactivation of the plugin and make the flow of an "Enrollment Request" in the dashboard (with the functionalities that we have so far) to check that there is no invocation to an existing class that cannot be found because of the namespace statements.


## Checklist for Merge

- [X] Tested in a remote environment
- [X] Rebased master/main
- [X] Squashed commits
