### PR TITLE
feat: enable redirection button to order or enrollment request

### DIFF
--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -210,7 +210,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 * 
 	 * @return void
 	 */
-	function my_woocommerce_admin_order_item_values($_product, $item, $item_id = null) {
+	function add_admin_order_item_values($_product, $item, $item_id = null) {
 
 		$order_id = method_exists($item, 'get_order_id') ? $item->get_order_id() : $item['order_id'];
 		$input_value = get_post_meta($order_id, 'enrollment_id' . $item_id, true);

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -218,7 +218,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 	
 		$html_output = '<td>';
 		$html_output .= '<input type="text" name="order_id_input' . $item_id . '" value="' . esc_attr($input_value) . '" pattern="\d*" />';
-		$html_output .= '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px;" ' . ($input_value ? '' : 'disabled') . '>Ir a la orden</a>';
+		$html_output .= '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px; ' . ($input_value ? '' : 'pointer-events: none; opacity: 0.6;') . '">Ir a la orden</a>';
 		$html_output .= '</td>';
 
 		echo $html_output;

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -186,4 +186,58 @@ class Openedx_Woocommerce_Plugin_Admin {
         return new Openedx_Woocommerce_Plugin_Post_Type($post_type, $plural, $single, $description, $options);
 
     }
+
+	/**
+	 * Create a custom column in order items table inside an order
+	 * 
+	 * @param array $columns Array of order items table columns
+	 * 
+	 * @return void
+	 */
+	function add_custom_column_order_items($columns)
+	{
+		$column_name = 'Test Column';
+		echo '<th>' . $column_name . '</th>';
+	}
+
+	/**
+	 * Create a custom input in the new column in order items table
+	 * to store the enrollment id and a link to the enrollment request
+	 * 
+	 * @param array $_product Product object
+	 * @param array $item Order item
+	 * @param int $item_id Order item id
+	 * 
+	 * @return void
+	 */
+	function my_woocommerce_admin_order_item_values($_product, $item, $item_id = null) {
+
+		$order_id = method_exists($item, 'get_order_id') ? $item->get_order_id() : $item['order_id'];
+		$input_value = get_post_meta($order_id, 'enrollment_id' . $item_id, true);
+		$order_url = admin_url('post.php?post=' . intval($input_value) . '&action=edit');
+	
+		echo '<td>';
+		echo '<input type="text" name="order_id_input' . $item_id . '" value="' . esc_attr($input_value) . '" />';
+		echo '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px;">Ir a la orden</a>';
+		echo '</td>';
+	}
+
+	/**
+	 * Save the enrollment id in the order meta data
+	 * 
+	 * @param int $order_id Order id
+	 * 
+	 * @return void
+	 */
+	function save_order_meta_data($order_id)
+	{
+		$items = wc_get_order($order_id)->get_items();
+
+		foreach ($items as $item_id => $item) {
+			if (isset($_POST['order_id_input' . $item_id])) {
+				$input_value = sanitize_text_field($_POST['order_id_input' . $item_id]);
+				update_post_meta($order_id, 'enrollment_id' . $item_id, $input_value);
+			}
+		}
+	}
 }

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -196,7 +196,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 */
 	function add_custom_column_order_items($columns)
 	{
-		$column_name = 'Test Column';
+		$column_name = 'Related Enrollment Request';
 		echo '<th>' . $column_name . '</th>';
 	}
 
@@ -216,10 +216,12 @@ class Openedx_Woocommerce_Plugin_Admin {
 		$input_value = get_post_meta($order_id, 'enrollment_id' . $item_id, true);
 		$order_url = admin_url('post.php?post=' . intval($input_value) . '&action=edit');
 	
-		echo '<td>';
-		echo '<input type="text" name="order_id_input' . $item_id . '" value="' . esc_attr($input_value) . '" pattern="\d*" />';
-		echo '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px;" ' . ($input_value ? '' : 'disabled') . '>Ir a la orden</a>';
-		echo '</td>';
+		$html_output = '<td>';
+		$html_output .= '<input type="text" name="order_id_input' . $item_id . '" value="' . esc_attr($input_value) . '" pattern="\d*" />';
+		$html_output .= '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px;" ' . ($input_value ? '' : 'disabled') . '>Ir a la orden</a>';
+		$html_output .= '</td>';
+
+		echo $html_output;
 	}
 
 	/**

--- a/admin/Openedx_Woocommerce_Plugin_Admin.php
+++ b/admin/Openedx_Woocommerce_Plugin_Admin.php
@@ -217,8 +217,8 @@ class Openedx_Woocommerce_Plugin_Admin {
 		$order_url = admin_url('post.php?post=' . intval($input_value) . '&action=edit');
 	
 		echo '<td>';
-		echo '<input type="text" name="order_id_input' . $item_id . '" value="' . esc_attr($input_value) . '" />';
-		echo '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px;">Ir a la orden</a>';
+		echo '<input type="text" name="order_id_input' . $item_id . '" value="' . esc_attr($input_value) . '" pattern="\d*" />';
+		echo '<a href="' . esc_url($order_url) . '" class="button" style="margin-left: 5px;" ' . ($input_value ? '' : 'disabled') . '>Ir a la orden</a>';
 		echo '</td>';
 	}
 

--- a/admin/css/openedx-woocommerce-plugin-admin.css
+++ b/admin/css/openedx-woocommerce-plugin-admin.css
@@ -29,3 +29,7 @@
 .logs_box strong {
     font-weight: bold;
 }
+
+.wp-core-ui .button, .wp-core-ui .button-secondary{
+    vertical-align: unset;
+}

--- a/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
@@ -169,13 +169,12 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
                 <tr>
                     <td class="first"><label for="openedx_enrollment_order_id">WC Order ID</label></td>
                     <td>
-                        <div style="width: 30%; display: inline-table;">
-                            <input type="text" id="openedx_enrollment_order_id" name="enrollment_order_id"
-                            value="<?php echo( $order_id ); ?>">
-                        </div>
-                        <div style="width: 30%; display: inline-table;">
-                            <a href="<?php if(isset($order_url)) echo $order_url ?>" class="button view_order_button">View Order</a>
-                        </div>
+                    <div style="width: 30%; display: inline-table;">
+                        <input type="text" id="openedx_enrollment_order_id" name="enrollment_order_id" value="<?php echo esc_attr( $order_id ); ?>" pattern="\d*" title="Please enter a numeric value" />
+                    </div>
+                    <div style="width: 30%; display: inline-table;">
+                        <a href="<?php if ( isset( $order_url ) ) echo esc_url( $order_url ); ?>" class="button view_order_button" <?php echo empty( $order_id ) ? 'disabled' : ''; ?>>View Order</a>
+                    </div>
                     </td>
                 </tr>
 

--- a/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
@@ -169,12 +169,12 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
                 <tr>
                     <td class="first"><label for="openedx_enrollment_order_id">WC Order ID</label></td>
                     <td>
-                    <div style="width: 30%; display: inline-table;">
-                        <input type="text" id="openedx_enrollment_order_id" name="enrollment_order_id" value="<?php echo esc_attr( $order_id ); ?>" pattern="\d*" title="Please enter a numeric value" />
-                    </div>
-                    <div style="width: 30%; display: inline-table;">
-                        <a href="<?php if ( isset( $order_url ) ) echo esc_url( $order_url ); ?>" class="button view_order_button" <?php echo empty( $order_id ) ? 'disabled' : ''; ?>>View Order</a>
-                    </div>
+                        <div style="width: 30%; display: inline-table;">
+                            <input type="text" id="openedx_enrollment_order_id" name="enrollment_order_id" value="<?php echo esc_attr( $order_id ); ?>" pattern="\d*" />
+                        </div>
+                        <div style="width: 30%; display: inline-table;">
+                            <a href="<?php if ( isset( $order_url ) ) echo esc_url( $order_url ); ?>" class="button view_order_button" style="<?php echo empty( $order_id ) ? 'pointer-events: none; opacity: 0.6;' : ''; ?>">View Order</a>
+                        </div>
                     </td>
                 </tr>
 

--- a/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
@@ -66,6 +66,9 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
         $mode      = get_post_meta( $post_id, 'mode', true );
         $is_active = get_post_meta( $post_id, 'is_active', true );
         $order_id  = get_post_meta( $post_id, 'order_id', true );
+        if($order_id){
+            $order_url = admin_url( 'post.php?post=' . intval($order_id) ) . '&action=edit';
+        }
 
         $new_enrollment = false;
         if (! $course_id && ! $email) {
@@ -171,7 +174,7 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
                             value="<?php echo( $order_id ); ?>">
                         </div>
                         <div style="width: 30%; display: inline-table;">
-                            <?php edit_post_link( 'view', '<p>', '</p>', $order_id ); ?>
+                            <a href="<?php if(isset($order_url)) echo $order_url ?>" class="button view_order_button">View Order</a>
                         </div>
                     </td>
                 </tr>

--- a/includes/Openedx_Woocommerce_Plugin.php
+++ b/includes/Openedx_Woocommerce_Plugin.php
@@ -180,11 +180,15 @@ class Openedx_Woocommerce_Plugin {
 
 		// Render enrollment request info form
 		$this->loader->add_action( 'edit_form_after_title', $plugin_admin, 'render_enrollment_info_form' );
-
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_filter( 'gettext', $this, 'openedx_plugin_custom_post_message', 10, 3 );
 		$this->loader->wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . '../admin/css/openedx-woocommerce-plugin-admin.css', array(), $this->version, 'all' );
+
+		// Redirection from enrollment to order and enrollment to order
+		$this->loader->add_filter('woocommerce_admin_order_item_headers', $plugin_admin, 'add_custom_column_order_items');
+		$this->loader->add_action('woocommerce_admin_order_item_values', $plugin_admin, 'my_woocommerce_admin_order_item_values', 10, 3);
+		$this->loader->add_action('save_post_shop_order', $plugin_admin, 'save_order_meta_data');
 
 	}
 

--- a/includes/Openedx_Woocommerce_Plugin.php
+++ b/includes/Openedx_Woocommerce_Plugin.php
@@ -187,7 +187,7 @@ class Openedx_Woocommerce_Plugin {
 
 		// Redirection from enrollment to order and enrollment to order
 		$this->loader->add_filter('woocommerce_admin_order_item_headers', $plugin_admin, 'add_custom_column_order_items');
-		$this->loader->add_action('woocommerce_admin_order_item_values', $plugin_admin, 'my_woocommerce_admin_order_item_values', 10, 3);
+		$this->loader->add_action('woocommerce_admin_order_item_values', $plugin_admin, 'add_admin_order_item_values', 10, 3);
 		$this->loader->add_action('save_post_shop_order', $plugin_admin, 'save_order_meta_data');
 
 	}


### PR DESCRIPTION
## Description

The functionality has been added to the Enrollment Request, so that whenever there is an associated order_id, a button labeled "View Order" is enabled, allowing users to be redirected to the associated order with just one click. Now, within an order, in the product items, if an Enrollment Request ID is set for them, a button is enabled that allows users to be redirected to the Enrollment Request associated with that item in that order.

## Testing instructions

Go to the Enrollment Request and enter an order_id in the order_id field, then save the changes. Click on the button to be redirected to the associated order. Similarly, from an order, if any product item has a set Enrollment Request ID, click on the corresponding button to be redirected to the linked Enrollment Request.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits