### PR TITLE
style: improve visual ergonomy

### DIFF
--- a/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Enrollment_Info_Form.php
@@ -173,12 +173,6 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
                                 <?php esc_html_e('Process no pre-enrollment --force', 'wp-edunext-marketing-site'); ?>
                             </option>
                         </select>
-                    </td>
-                </tr>
-                    
-                <tr>
-                    <td class="first"><label>Create/Update Enrollment</label></td>
-                    <td>
                         <button class="button save_order button-primary"><span><?php esc_html_e('Apply action', 'wp-edunext-marketing-site'); ?></span></button>
                     </td>
                 </tr>

--- a/includes/model/Openedx_Woocommerce_Plugin_Logs.php
+++ b/includes/model/Openedx_Woocommerce_Plugin_Logs.php
@@ -49,7 +49,7 @@ class Openedx_Woocommerce_Plugin_Log {
 
             if (empty($old_data_array['enrollment_course_id'])) {
                 $log_data['object_status'] = 'Object Created';
-                $old_data_array = '--';
+                $log_data['object_before'] = "--";
             }else{
                 $log_data['object_status'] = 'Object Modified';
             } 


### PR DESCRIPTION
## Description

A change was implemented in the user interface regarding the placement of the Apply Action button, which was previously located at the bottom of the form and was decoupled from the intended action. It has now been relocated to the side of the dropdown. Also, in the logs, when an object is new, the 'object_before' property is assigned as '--,' indicating that it is a new object.

## Testing instructions

To test this, simply enter the form and review the visual settings.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits