### PR TITLE
feat: settings section for openedx plugin configuration

### DIFF
--- a/admin/css/openedx-woocommerce-plugin-admin.css
+++ b/admin/css/openedx-woocommerce-plugin-admin.css
@@ -33,3 +33,16 @@
 .wp-core-ui .button, .wp-core-ui .button-secondary{
     vertical-align: unset;
 }
+
+.openedx-jwt-token-input {
+    flex: 1;
+}
+
+#generate-jwt-token {
+    margin-left: 10px;
+}
+
+input[type="text"],
+input[type="password"] {
+    width: 30%; /* Ajusta la altura según tus preferencias */
+}

--- a/admin/css/openedx-woocommerce-plugin-admin.css
+++ b/admin/css/openedx-woocommerce-plugin-admin.css
@@ -44,5 +44,5 @@
 
 input[type="text"],
 input[type="password"] {
-    width: 30%; /* Ajusta la altura según tus preferencias */
+    width: 30%;
 }

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -235,6 +235,15 @@ class Openedx_Woocommerce_Plugin_Settings
         return preg_replace('/[^a-zA-Z0-9]/', '', sanitize_text_field($input));
     }
 
+    /**
+     * Sanitize and validate the Open edX instance URL input.
+     *
+     * This sanitizes the input URL, checks if it is a valid http/https URL, 
+     * and returns the sanitized URL string on success or an empty string on failure.
+     *
+     * @param string $input The URL input to sanitize.
+     * @return string The sanitized URL string on success, empty string on failure.
+     */
     public function custom_sanitize_url($input) 
     {
         $url = esc_url_raw($input);

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -198,16 +198,13 @@ class Openedx_Woocommerce_Plugin_Settings
         <div class="openedx-jwt-token-wrapper">
 
             <input class="openedx-jwt-token-input" type="text" name="openedx-jwt-token" id="openedx-jwt-token"
-                value="<?php echo esc_attr($masked_value); ?>" />
+                value="<?php echo esc_attr($masked_value); ?>" disabled/>
 
             <button class="button" type="button" id="generate-jwt-token">Generate JWT Token</button>
 
         </div>
 
-        <p class="description">
-        Leave blank if you're going to generate the token, otherwise enter the JWT 
-        token and save.
-        </p>
+        <p class="description"> Select the Generate Token button to obtain a JWT Token. </p>
 
     <?php
     }

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -98,7 +98,7 @@ class Openedx_Woocommerce_Plugin_Settings
         register_setting(
             'openedx-settings-group',
             'openedx-domain',
-            array($this, 'custom_sanitize_alphanumeric')
+            array($this, 'custom_sanitize_url')
         );
     
         register_setting(
@@ -192,7 +192,7 @@ class Openedx_Woocommerce_Plugin_Settings
     public function openedx_jwt_token_callback()
     {
 
-        $value = get_option('openedx-jwt-token');
+        $value = "12121adsad112ad";
         $masked_value = str_repeat('*', strlen($value) - 4) . substr($value, -4); ?>
 
         <div class="openedx-jwt-token-wrapper">
@@ -233,6 +233,25 @@ class Openedx_Woocommerce_Plugin_Settings
     public function custom_sanitize_alphanumeric($input) 
     {
         return preg_replace('/[^a-zA-Z0-9]/', '', sanitize_text_field($input));
+    }
+
+    public function custom_sanitize_url($input) 
+    {
+        $url = esc_url_raw($input);
+
+        if (empty($url)) {
+            return '';
+        }
+
+        $parsed_url = wp_parse_url($url);
+        
+        if (isset($parsed_url['scheme']) 
+        && ($parsed_url['scheme'] === 'http' 
+        || $parsed_url['scheme'] === 'https')) {
+            return $url;
+        }
+
+        return '';
     }
     
 }

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -98,25 +98,25 @@ class Openedx_Woocommerce_Plugin_Settings
         register_setting(
             'openedx-settings-group',
             'openedx-domain',
-            array($this, 'custom_sanitize_url')
+            array($this, 'sanitize_url_in')
         );
     
         register_setting(
             'openedx-settings-group',
             'openedx-client-id',
-            array($this, 'custom_sanitize_alphanumeric')
+            array($this, 'sanitize_text_in')
         );
     
         register_setting(
             'openedx-settings-group',
             'openedx-client-secret',
-            array($this, 'custom_sanitize_alphanumeric')
+            array($this, 'sanitize_text_in')
         );
     
         register_setting(
             'openedx-settings-group',
             'openedx-jwt-token',
-            array($this, 'custom_sanitize_alphanumeric')
+            array($this, 'sanitize_text_in')
         );
     }
 
@@ -228,9 +228,9 @@ class Openedx_Woocommerce_Plugin_Settings
      * @param string $input The input string to sanitize.
      * @return string The sanitized input string containing only alphanumeric characters.
      */
-    public function custom_sanitize_alphanumeric($input) 
+    public function sanitize_text_in($input) 
     {
-        return preg_replace('/[^a-zA-Z0-9]/', '', sanitize_text_field($input));
+        return sanitize_text_field($input);
     }
 
     /**
@@ -242,23 +242,9 @@ class Openedx_Woocommerce_Plugin_Settings
      * @param string $input The URL input to sanitize.
      * @return string The sanitized URL string on success, empty string on failure.
      */
-    public function custom_sanitize_url($input) 
+    public function sanitize_url_in($input) 
     {
-        $url = esc_url_raw($input);
-
-        if (empty($url)) {
-            return '';
-        }
-
-        $parsed_url = wp_parse_url($url);
-        
-        if (isset($parsed_url['scheme']) 
-        && ($parsed_url['scheme'] === 'http' 
-        || $parsed_url['scheme'] === 'https')) {
-            return $url;
-        }
-
-        return '';
+        return sanitize_url($input);
     }
     
 }

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -98,25 +98,25 @@ class Openedx_Woocommerce_Plugin_Settings
         register_setting(
             'openedx-settings-group',
             'openedx-domain',
-            array($this, 'sanitize_url_in')
+            'sanitize_url'
         );
     
         register_setting(
             'openedx-settings-group',
             'openedx-client-id',
-            array($this, 'sanitize_text_in')
+            'sanitize_text_field'
         );
     
         register_setting(
             'openedx-settings-group',
             'openedx-client-secret',
-            array($this, 'sanitize_text_in')
+            'sanitize_text_field'
         );
     
         register_setting(
             'openedx-settings-group',
             'openedx-jwt-token',
-            array($this, 'sanitize_text_in')
+            'sanitize_text_field'
         );
     }
 
@@ -218,33 +218,6 @@ class Openedx_Woocommerce_Plugin_Settings
     {
         printf( 'Configuring the necessary parameters here to establish
         the connection between this plugin and your Open edX platform.');
-    }
-
-    /**
-     * Sanitize input string to only contain alphanumeric characters.
-     *
-     * This removes any non-alphanumeric characters from the given input string.
-     *
-     * @param string $input The input string to sanitize.
-     * @return string The sanitized input string containing only alphanumeric characters.
-     */
-    public function sanitize_text_in($input) 
-    {
-        return sanitize_text_field($input);
-    }
-
-    /**
-     * Sanitize and validate the Open edX instance URL input.
-     *
-     * This sanitizes the input URL, checks if it is a valid http/https URL, 
-     * and returns the sanitized URL string on success or an empty string on failure.
-     *
-     * @param string $input The URL input to sanitize.
-     * @return string The sanitized URL string on success, empty string on failure.
-     */
-    public function sanitize_url_in($input) 
-    {
-        return sanitize_url($input);
     }
     
 }

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\admin\views;
+
+class Openedx_Woocommerce_Plugin_Settings
+{
+
+    /**
+     * Add the plugin settings submenu page.
+     *
+     * Registers a new administration submenu page under the Settings menu
+     * for the Open edX plugin settings.
+     *
+     * @return void
+     */
+    public function openedx_settings_submenu() 
+    {
+        add_submenu_page(
+            'options-general.php',
+            'Open edX Settings',
+            'Open edX Sync',
+            'manage_options',
+            'openedx-settings',
+            array($this, 'openedx_settings_page')
+        );
+    }
+
+    /**
+     * Output the plugin settings page.
+     *
+     * Renders the form and fields for the Open edX plugin settings page.
+     *
+     * @return void
+     */
+    public function openedx_settings_page() 
+    {
+        ?>
+        <div class="wrap">
+            <h2>Open edX Settings</h2>
+            <form method="post" action="options.php">
+                <?php settings_fields('openedx-settings-group'); ?>
+                <?php do_settings_sections('openedx-settings'); ?>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Register settings and fields.
+     *
+     * Uses the Settings API to register the settings section, fields, and options
+     * for the Open edX plugin configuration. 
+     *
+     * @return void
+     */
+    function openedx_settings_init() 
+    {
+        add_settings_section(
+            'openedx-settings-section',
+            '',
+            array($this, 'openedx_settings_section_callback'),
+            'openedx-settings'
+        );
+    
+        add_settings_field(
+            'openedx-domain',
+            'Open edX Domain',
+            array($this, 'openedx_domain_callback'),
+            'openedx-settings',
+            'openedx-settings-section'
+        );
+    
+        add_settings_field(
+            'openedx-client-id',
+            'Client id',
+            array($this, 'openedx_client_id_callback'),
+            'openedx-settings',
+            'openedx-settings-section'
+        );
+    
+        add_settings_field(
+            'openedx-client-secret',
+            'Client secret',
+            array($this, 'openedx_client_secret_callback'),
+            'openedx-settings',
+            'openedx-settings-section'
+        );
+    
+        add_settings_field(
+            'openedx-jwt-token',
+            'JWT Token',
+            array($this, 'openedx_jwt_token_callback'),
+            'openedx-settings',
+            'openedx-settings-section'
+        );
+    
+        register_setting(
+            'openedx-settings-group',
+            'openedx-domain',
+            array($this, 'custom_sanitize_alphanumeric')
+        );
+    
+        register_setting(
+            'openedx-settings-group',
+            'openedx-client-id',
+            array($this, 'custom_sanitize_alphanumeric')
+        );
+    
+        register_setting(
+            'openedx-settings-group',
+            'openedx-client-secret',
+            array($this, 'custom_sanitize_alphanumeric')
+        );
+    
+        register_setting(
+            'openedx-settings-group',
+            'openedx-jwt-token',
+            array($this, 'custom_sanitize_alphanumeric')
+        );
+    }
+
+    /**
+     * Output the domain settings field.
+     *
+     * Retrieves the saved domain value and outputs an input field and description text.
+     *
+     * @return void
+     */
+    public function openedx_domain_callback()
+    {
+        $value = get_option( 'openedx-domain' ); ?>
+
+        <input type="text" name="openedx-domain" id="openedx-domain" 
+            value="<?php echo esc_attr( $value ); ?>" required />
+
+        <p class='description'>Your Open edX platform's web address.</p>
+
+        <?php
+    }
+
+    /**
+     * Output the client ID settings field. 
+     *
+     * Retrieves the saved client ID value and outputs an input field and description text.
+     *
+     * @return void
+     */
+    public function openedx_client_id_callback()
+    {
+        $value = get_option( 'openedx-client-id' ); ?>
+
+        <input type="text" name="openedx-client-id" id="openedx-client-id" 
+            value="<?php echo esc_attr( $value ); ?>" required />
+
+        <p class="description">Identifier for OAuth application in your Open edX 
+            platform.</p>
+
+    <?php
+    }
+
+    /**
+     * Output the client secret settings field.
+     *
+     * Retrieves the saved client secret value and outputs a password input field and description text.
+     *
+     * @return void
+     */
+    public function openedx_client_secret_callback()
+    {
+
+        $value = get_option( 'openedx-client-secret' ); ?>
+
+        <input type="text" name="openedx-client-secret" id="openedx-client-secret" 
+            value="<?php echo esc_attr( $value ); ?>" required />
+
+        <p class="description">
+            Confidential key for OAuth application in your Open edX platform.
+        </p>
+
+    <?php
+    }
+
+    /** 
+     * Output the JWT token settings field.
+     *
+     * Retrieves the saved JWT token value and outputs a text input field, generate token button,
+     * and description text.
+     *
+     * @return void
+     */
+    public function openedx_jwt_token_callback()
+    {
+
+        $value = get_option('openedx-jwt-token');
+        $masked_value = str_repeat('*', strlen($value) - 4) . substr($value, -4); ?>
+
+        <div class="openedx-jwt-token-wrapper">
+
+            <input class="openedx-jwt-token-input" type="text" name="openedx-jwt-token" id="openedx-jwt-token"
+                value="<?php echo esc_attr($masked_value); ?>" />
+
+            <button class="button" type="button" id="generate-jwt-token">Generate JWT Token</button>
+
+        </div>
+
+        <p class="description">
+        Leave blank if you're going to generate the token, otherwise enter the JWT 
+        token and save.
+        </p>
+
+    <?php
+    }
+
+    /**
+     * Output introductory text for the settings section.
+     *
+     * Echoes text prompting the user to fill in and save the settings.
+     * 
+     * @return void
+     */
+    function openedx_settings_section_callback()
+    {
+        printf( 'Configuring the necessary parameters here to establish
+        the connection between this plugin and your Open edX platform.');
+    }
+
+    /**
+     * Sanitize input string to only contain alphanumeric characters.
+     *
+     * This removes any non-alphanumeric characters from the given input string.
+     *
+     * @param string $input The input string to sanitize.
+     * @return string The sanitized input string containing only alphanumeric characters.
+     */
+    function custom_sanitize_alphanumeric($input) 
+    {
+        return preg_replace('/[^a-zA-Z0-9]/', '', sanitize_text_field($input));
+    }
+    
+}

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -191,14 +191,12 @@ class Openedx_Woocommerce_Plugin_Settings
      */
     public function openedx_jwt_token_callback()
     {
-
-        $value = "12121adsad112ad";
-        $masked_value = str_repeat('*', strlen($value) - 4) . substr($value, -4); ?>
+        ?>
 
         <div class="openedx-jwt-token-wrapper">
 
             <input class="openedx-jwt-token-input" type="text" name="openedx-jwt-token" id="openedx-jwt-token"
-                value="<?php echo esc_attr($masked_value); ?>" disabled/>
+                value="" disabled/>
 
             <button class="button" type="button" id="generate-jwt-token">Generate JWT Token</button>
 

--- a/admin/views/Openedx_Woocommerce_Plugin_Settings.php
+++ b/admin/views/Openedx_Woocommerce_Plugin_Settings.php
@@ -54,7 +54,7 @@ class Openedx_Woocommerce_Plugin_Settings
      *
      * @return void
      */
-    function openedx_settings_init() 
+    public function openedx_settings_init() 
     {
         add_settings_section(
             'openedx-settings-section',
@@ -219,7 +219,7 @@ class Openedx_Woocommerce_Plugin_Settings
      * 
      * @return void
      */
-    function openedx_settings_section_callback()
+    public function openedx_settings_section_callback()
     {
         printf( 'Configuring the necessary parameters here to establish
         the connection between this plugin and your Open edX platform.');
@@ -233,7 +233,7 @@ class Openedx_Woocommerce_Plugin_Settings
      * @param string $input The input string to sanitize.
      * @return string The sanitized input string containing only alphanumeric characters.
      */
-    function custom_sanitize_alphanumeric($input) 
+    public function custom_sanitize_alphanumeric($input) 
     {
         return preg_replace('/[^a-zA-Z0-9]/', '', sanitize_text_field($input));
     }

--- a/includes/Openedx_Woocommerce_Plugin.php
+++ b/includes/Openedx_Woocommerce_Plugin.php
@@ -4,6 +4,8 @@ namespace App;
 
 use App\admin\Openedx_Woocommerce_Plugin_Admin;
 use App\public\Openedx_Woocommerce_Plugin_Public;
+use App\admin\views\Openedx_Woocommerce_Plugin_Settings;
+
 
 /**
  * The file that defines the core plugin class
@@ -85,6 +87,7 @@ class Openedx_Woocommerce_Plugin
 		$this->set_locale();
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
+		$this->define_plugin_settings_hooks();
 	 }
 
 	/**
@@ -161,6 +164,12 @@ class Openedx_Woocommerce_Plugin
          */
 		include_once plugin_dir_path(dirname(__FILE__))
 			. 'utils/Openedx_Utils.php';
+
+		/**
+		 * 
+		 */
+		include_once plugin_dir_path(dirname(__FILE__))
+			. 'admin/views/Openedx_Woocommerce_Plugin_Settings.php';
 	}
 
 	/**
@@ -209,20 +218,23 @@ class Openedx_Woocommerce_Plugin
 		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
 		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts');
 		$this->loader->add_filter('gettext', $this, 'openedx_plugin_custom_post_message', 10, 3);
-		$this->loader->wp_enqueue_style($this->plugin_name, 
-										plugin_dir_url(__FILE__) 
-										. '../admin/css/openedx-woocommerce-plugin-admin.css', 
-										array(), 
-										$this->version, 
-										'all');
+		$this->loader->wp_enqueue_style(
+			$this->plugin_name, 
+			plugin_dir_url(__FILE__) . '../admin/css/openedx-woocommerce-plugin-admin.css', 
+			array(), 
+			$this->version, 
+			'all'
+		);
 
 		// Redirection from enrollment to order and enrollment to order
 		$this->loader->add_filter('woocommerce_admin_order_item_headers', $plugin_admin, 'add_custom_column_order_items');
 		$this->loader->add_action('woocommerce_admin_order_item_values', $plugin_admin, 'add_admin_order_item_values', 10, 3);
 		$this->loader->add_action('save_post_shop_order', $plugin_admin, 'save_order_meta_data');
-		$this->loader->add_action('woocommerce_product_options_general_product_data', 
-								  $plugin_admin, 
-								  'add_custom_product_fields');
+		$this->loader->add_action(
+			'woocommerce_product_options_general_product_data', 
+			$plugin_admin, 
+			'add_custom_product_fields'
+		);
 		$this->loader->add_action('woocommerce_process_product_meta', 
 								  $plugin_admin, 
 								  'save_custom_product_fields');
@@ -244,6 +256,23 @@ class Openedx_Woocommerce_Plugin
 
          $this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_styles');
          $this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_scripts');
+	}
+
+	/**
+	 * Define the plugin settings hooks.
+	 *
+	 * Initializes the Openedx_Woocommerce_Plugin_Settings class 
+	 * and registers its admin menu and settings hooks using the loader.
+	 * 
+	 * @return void
+	 */  
+	private function define_plugin_settings_hooks()
+	{
+
+		$plugin_settings = new Openedx_Woocommerce_Plugin_Settings();
+
+		$this->loader->add_action('admin_menu', $plugin_settings, 'openedx_settings_submenu');
+		$this->loader->add_action('admin_init', $plugin_settings, 'openedx_settings_init');
 	}
 
     /**


### PR DESCRIPTION
## Description

An element is created in the Settings submenu on the Dashboard called 'Open edX Sync,' which, upon entering, displays a form where the user will input their domain, ID, and other details to be synchronized with the plugin.

## Testing instructions

Simply access the option and fill out the form.

## Additional information

For the text fields, a function named custom_sanitize_alphanumeric was created, which currently defaults to accepting only alphanumeric values, so that if special characters are entered, they will be removed.

The plugin's settings information is stored in the WordPress database because there is a hook available to query it easily in the case of configurations.

The frontend looks like this:
![image](https://github.com/eduNEXT/openedx-woocommerce-plugin/assets/52968528/1274eea0-89e4-4311-9a8f-73cc351f50ca)


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits
