### PR TITLE
fix: ci and wpcs workflow fixes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--no-dev"
 
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,14 +30,14 @@ jobs:
         with:
           find: "Version: *[0-9.]*"
           replace: "Version:           ${{ steps.tag_version.outputs.new_version }}"
-          include: "class-openedx-woocommerce-plugin.php"
+          include: "openedx-woocommerce-plugin.php"
           
       - name: Update php file version - define statement
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "(define\\( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', ')([^']*)(.*);"
           replace: "define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '${{ steps.tag_version.outputs.new_version }}' );"
-          include: "class-openedx-woocommerce-plugin.php"
+          include: "openedx-woocommerce-plugin.php"
           
       - name: Update README version
         uses: jacobtomlinson/gha-find-replace@v3
@@ -60,7 +60,7 @@ jobs:
         with:
           branch: ${{ github.ref }}
           commit_message: "docs(bumpversion): ${{ steps.tag_version.outputs.previous_tag }} → ${{ steps.tag_version.outputs.new_tag }}"
-          file_pattern: README.txt CHANGELOG.md class-openedx-woocommerce-plugin.php
+          file_pattern: README.txt CHANGELOG.md openedx-woocommerce-plugin.php
           
   release:
     needs: bumpversion

--- a/.github/workflows/wordpress-cs-check.yml
+++ b/.github/workflows/wordpress-cs-check.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
+          composer-options: "--no-dev"
 
       - name: Run PHPCS checks
         id: phpcs

--- a/.github/workflows/wordpress-cs-check.yml
+++ b/.github/workflows/wordpress-cs-check.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
-          composer-options: "--no-dev"
 
       - name: Run PHPCS checks
         id: phpcs


### PR DESCRIPTION
## Description

A parameter is corrected in the CI workflow that was incorrect due to the filename. Previously, it was named 'class-openedx-woocommerce-plugin', and now it is named 'openedx-woocommerce-plugin'. Additionally, the '--no-dev' property is added to the composer install in the WPCS workflow to install only the dependencies required for production, rather than all of them.

## Testing instructions

To test, please download the file and try it either locally or on the staging environment.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits