### PR TITLE
fix: handler of fatal error in settings page corrected

### DIFF
--- a/admin/views/class-openedx-woocommerce-plugin-settings.php
+++ b/admin/views/class-openedx-woocommerce-plugin-settings.php
@@ -195,22 +195,14 @@ class Openedx_Woocommerce_Plugin_Settings {
 			exit();
 		} else {
 
-			settings_errors( 'openedx-settings', 'true' );
-			if ( 'error_has_response' === $response_message ) {
-				add_settings_error(
-					'token_error',
-					'token_error',
-					'Error: ' . $response[1] . ' - ' . json_decode( $response[2], true )['error']
-				);
-			} else {
-				add_settings_error(
-					'token_error',
-					'token_error',
-					'Error: ' . $response[1]->getMessage()
-				);
-			}
+			add_settings_error(
+				'token_error',
+				'token_error',
+				'Error: ' . $response[1],
+			);
 		}
 	}
+
 
 	/**
 	 * Output the domain settings field.


### PR DESCRIPTION
## Description

Fixed an issue where a WordPress fatal error occurred when there was an error in the form information on the plugin's settings page, causing a severe disruption in the workflow. Now, the error is displayed as a card above the form. to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Testing instructions

Go to the staging and trigger an error by entering incorrect information in the form and attempting to generate a new token.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

