### PR TITLE
feat: enrollment creation when an order is processed

### DIFF
--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -347,12 +347,13 @@ class Openedx_Woocommerce_Plugin_Admin {
 	public function process_order_data( $order_id ) {
 
 		$order         = wc_get_order( $order_id );
-		$billing_email = $order->get_billing_email();
 		$status        = $order->get_status();
 		$enrollment_id = '';
 		$courses       = array();
 
 		if ( 'processing' === $status ) {
+
+			$billing_email = $order->get_billing_email();
 
 			$courses = $this->select_course_items( $order, $billing_email );
 
@@ -380,7 +381,10 @@ class Openedx_Woocommerce_Plugin_Admin {
 			$course_id  = get_post_meta( $product_id, '_course_id', true );
 
 			if ( '' !== $course_id ) {
-				$courses[] = array( $item, $item_id );
+				$courses[] = array(
+					'course_item'    => $item,
+					'course_item_id' => $item_id,
+				);
 			}
 		}
 
@@ -400,8 +404,8 @@ class Openedx_Woocommerce_Plugin_Admin {
 
 		foreach ( $courses as $item_id => $item ) {
 
-			$course_id    = get_post_meta( $item[0]->get_product_id(), '_course_id', true );
-			$course_mode  = get_post_meta( $item[0]->get_product_id(), '_mode', true );
+			$course_id    = get_post_meta( $item['course_item']->get_product_id(), '_course_id', true );
+			$course_mode  = get_post_meta( $item['course_item']->get_product_id(), '_mode', true );
 			$request_type = 'enroll';
 			$action       = 'enrollment_process';
 
@@ -414,7 +418,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 			);
 
 			$enrollment_id = $this->openedx_enrollment->insert_new( $enrollment_arr, $action, $order_id );
-			update_post_meta( $order_id, 'enrollment_id' . $item[1], $enrollment_id->ID );
+			update_post_meta( $order_id, 'enrollment_id' . $item['course_item_id'], $enrollment_id->ID );
 			wc_create_order_note( $order_id, 'Enrollment Request ID: ' . $enrollment_id->ID . " Click <a href='" . admin_url( 'post.php?post=' . intval( $enrollment_id->ID ) . '&action=edit' ) . "'>here</a> for details." );
 		}
 	}

--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -438,6 +438,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 
 	/**
 	 * Check the API response from the Open edX API to show a simple message about the response.
+	 * The message will be displayed in order notes.
 	 *
 	 * @param array $response The API response.
 	 *

--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -337,15 +337,22 @@ class Openedx_Woocommerce_Plugin_Admin {
 		update_post_meta( $post_id, '_mode', $mode );
 	}
 
-	public function process_order_data( $order_id, $new_status ) {
+	/**
+	 * This function is called when an order payment is completed.
+	 *
+	 * @param int $order_id Order id.
+	 *
+	 * @return void
+	 */
+	public function process_order_data( $order_id ) {
 
 		$order         = wc_get_order( $order_id );
 		$billing_email = $order->get_billing_email();
 		$status        = $order->get_status();
 		$enrollment_id = '';
-		$courses       = [];
+		$courses       = array();
 
-		if ( $status === 'processing' ) {
+		if ( 'processing' === $status ) {
 
 			$courses = $this->select_course_items( $order, $billing_email );
 
@@ -356,16 +363,23 @@ class Openedx_Woocommerce_Plugin_Admin {
 		}
 	}
 
-	public function select_course_items( $order, $billing_email ) {
+	/**
+	 * Select the items that are courses in the order.
+	 *
+	 * @param object $order Order object.
+	 *
+	 * @return array $courses Array of courses.
+	 */
+	public function select_course_items( $order ) {
 
-		$items         = $order->get_items();
-		$courses       = [];
+		$items   = $order->get_items();
+		$courses = array();
 
 		foreach ( $items as $item_id => $item ) {
 			$product_id = $item->get_product_id();
 			$course_id  = get_post_meta( $product_id, '_course_id', true );
 
-			if ( $course_id !== '' ) { 
+			if ( '' !== $course_id ) {
 				$courses[] = array( $item, $item_id );
 			}
 		}
@@ -373,21 +387,30 @@ class Openedx_Woocommerce_Plugin_Admin {
 		return $courses;
 	}
 
+	/**
+	 * This function processes the enrollment request for each course in the order.
+	 *
+	 * @param array  $courses Array of courses.
+	 * @param int    $order_id Order id.
+	 * @param string $billing_email Billing email.
+	 *
+	 * @return void
+	 */
 	public function items_enrollment_request( $courses, $order_id, $billing_email ) {
 
 		foreach ( $courses as $item_id => $item ) {
-				
-			$course_id = get_post_meta( $item[0]->get_product_id() , '_course_id', true );
-			$course_mode = get_post_meta( $item[0]->get_product_id(), '_mode', true );
+
+			$course_id    = get_post_meta( $item[0]->get_product_id(), '_course_id', true );
+			$course_mode  = get_post_meta( $item[0]->get_product_id(), '_mode', true );
 			$request_type = 'enroll';
-			$action = "enrollment_process";
-			
+			$action       = 'enrollment_process';
+
 			$enrollment_arr = array(
-				'enrollment_course_id' => $course_id,
-				'enrollment_email' => $billing_email,
-				'enrollment_mode' => $course_mode,
+				'enrollment_course_id'    => $course_id,
+				'enrollment_email'        => $billing_email,
+				'enrollment_mode'         => $course_mode,
 				'enrollment_request_type' => $request_type,
-				'enrollment_order_id' => $order_id
+				'enrollment_order_id'     => $order_id,
 			);
 
 			$enrollment_id = $this->openedx_enrollment->insert_new( $enrollment_arr, $action, $order_id );
@@ -396,11 +419,26 @@ class Openedx_Woocommerce_Plugin_Admin {
 		}
 	}
 
+	/**
+	 * Shows the API logs in the order notes.
+	 *
+	 * @param int   $order_id Order id.
+	 * @param array $enrollment_api_response The API response.
+	 *
+	 * @return void
+	 */
 	public function show_enrollment_logs( $order_id, $enrollment_api_response ) {
 		$response = $this->check_api_response( $enrollment_api_response );
 		wc_create_order_note( $order_id, $response );
 	}
 
+	/**
+	 * Check the API response from the Open edX API to show a simple message about the response.
+	 *
+	 * @param array $response The API response.
+	 *
+	 * @return string $response The API response.
+	 */
 	public function check_api_response( $response ) {
 
 		switch ( $response[0] ) {

--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -392,7 +392,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 
 			$enrollment_id = $this->openedx_enrollment->insert_new( $enrollment_arr, $action, $order_id );
 			update_post_meta( $order_id, 'enrollment_id' . $item[1], $enrollment_id->ID );
-			wc_create_order_note( $order_id, 'Enrollment Request ID: ' . $enrollment_id->ID . " created. Click <a href='" . admin_url( 'post.php?post=' . intval( $enrollment_id->ID ) . '&action=edit' ) . "'>here</a> to see the Enrollment Request." );
+			wc_create_order_note( $order_id, 'Enrollment Request ID: ' . $enrollment_id->ID . " Click <a href='" . admin_url( 'post.php?post=' . intval( $enrollment_id->ID ) . '&action=edit' ) . "'>here</a> for details." );
 		}
 	}
 

--- a/includes/class-openedx-woocommerce-plugin.php
+++ b/includes/class-openedx-woocommerce-plugin.php
@@ -19,6 +19,7 @@ namespace App;
 use App\admin\Openedx_Woocommerce_Plugin_Admin;
 use App\public\Openedx_Woocommerce_Plugin_Public;
 use App\admin\views\Openedx_Woocommerce_Plugin_Settings;
+use App\model\Openedx_Woocommerce_Plugin_Enrollment;
 
 /**
  * This class contains the function to register a new custom post type.
@@ -241,6 +242,8 @@ class Openedx_Woocommerce_Plugin {
 			$plugin_admin,
 			'save_custom_product_fields'
 		);
+
+		$this->loader->add_action( 'woocommerce_order_status_changed', $plugin_admin, 'process_order_data', 10, 2 );
 	}
 
 	/**

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -13,6 +13,8 @@
 namespace App\model;
 
 use App\model\Openedx_Woocommerce_Plugin_Log;
+use App\Openedx_Woocommerce_Plugin;
+use App\admin\Openedx_Woocommerce_Plugin_Admin;
 use App\model\Openedx_Woocommerce_Plugin_Api_Calls;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -276,7 +278,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	 *
 	 * @return object $post The post object.
 	 */
-	public function insert_new( $enrollment_arr, $enrollment_action = '' ) {
+	public function insert_new( $enrollment_arr, $enrollment_action = '', $order_id = null ) {
 		$this->unregister_save_hook();
 
 		$new_enrollment = array(
@@ -286,7 +288,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 		$post_id        = wp_insert_post( $new_enrollment );
 		$post           = get_post( $post_id );
 
-		$this->save_enrollment( $post, $enrollment_arr, $enrollment_action );
+		$this->save_enrollment( $post, $enrollment_arr, $enrollment_action, $order_id );
 		return $post;
 	}
 
@@ -297,7 +299,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	 * @param array  $enrollment_arr An array containing the enrollment info.
 	 * @param string $enrollment_action The API action to perform once the wp process is done.
 	 */
-	public function save_enrollment( $post, $enrollment_arr, $enrollment_action ) {
+	public function save_enrollment( $post, $enrollment_arr, $enrollment_action, $order_id = null ) {
 
 		$post_id = $post->ID;
 
@@ -339,6 +341,12 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
 		$enrollment_api_response = $api->enrollment_send_request( $enrollment_data, $enrollment_action );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
+
+		if ( null !== $order_id ) {
+			$plugin_class = new Openedx_Woocommerce_Plugin();
+			$admin_class = new Openedx_Woocommerce_Plugin_Admin( $plugin_class->get_plugin_name(), $plugin_class->get_version() );
+			$admin_class->show_enrollment_logs( $order_id, $enrollment_api_response );
+		}
 	}
 
 

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -275,6 +275,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	 *
 	 * @param array  $enrollment_arr An array containing the enrollment info.
 	 * @param string $enrollment_action The API action to perform once the wp process is done.
+	 * @param int    $order_id The order ID in case the enrollment is created from an order.
 	 *
 	 * @return object $post The post object.
 	 */
@@ -298,6 +299,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	 * @param post   $post The post object.
 	 * @param array  $enrollment_arr An array containing the enrollment info.
 	 * @param string $enrollment_action The API action to perform once the wp process is done.
+	 * @param int    $order_id The order ID in case the enrollment is created from an order.
 	 */
 	public function save_enrollment( $post, $enrollment_arr, $enrollment_action, $order_id = null ) {
 
@@ -344,7 +346,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 
 		if ( null !== $order_id ) {
 			$plugin_class = new Openedx_Woocommerce_Plugin();
-			$admin_class = new Openedx_Woocommerce_Plugin_Admin( $plugin_class->get_plugin_name(), $plugin_class->get_version() );
+			$admin_class  = new Openedx_Woocommerce_Plugin_Admin( $plugin_class->get_plugin_name(), $plugin_class->get_version() );
 			$admin_class->show_enrollment_logs( $order_id, $enrollment_api_response );
 		}
 	}


### PR DESCRIPTION
## Description

A functionality has been created that allows a WooCommerce order, which has already been paid and is in the 'processing' state, to automatically create an Enrollment Request with the order information. In this case, the email used for processing will be the one associated with the billing information of the order.

This pull request includes only the 'happy path,' which means it works when all the information is correct and handles very basic errors. In other words, if there is a failure in the API request, it will be displayed in the notes, but if there are other types of errors, there is a possibility that the process may be interrupted.

## Testing instructions

To test it:

1. Go to the test product: https://stagingwoocommerceplugin.kinsta.cloud/?product=curso-de-pruebas-paypal
2. Click on the 'Add to Cart' button.
3. Click on the 'View Cart' button in the popup.
4. Click 'Proceed to Checkout.'
5. Change the user's email to a correct one, such as student-1@example.com, or a different one to test the case where it's incorrect.
6. Click on the 'PayPal' button.
7. For the email, enter: sb-x82l127360215@personal.example.com, and for the password: Sg="6{SA
8. Click 'Pay.'
9. Check the order in WooCommerce and its notes.

## Additional information

This is how a successful order looks like:

![image](https://github.com/eduNEXT/openedx-woocommerce-plugin/assets/52968528/88366aaf-d792-40f3-89d6-527ee4d54ec0)

In the event of a failure in the Open edX API request, you will see the error message at the location indicated by the arrow on the right side of the screen.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits
