### PR TITLE
feat: unenroll request when a refund is processed

### DIFF
--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -376,7 +376,7 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 *
 	 * @return array $courses Array of courses.
 	 */
-	public function select_course_items( $items, $is_refunded = null ) {
+	public function select_course_items( $items, $is_refunded = false ) {
 
 		$courses = array();
 

--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -260,22 +260,22 @@ class Openedx_Woocommerce_Plugin_Admin {
 	 * Create a custom input in the new column in order items table
 	 * to store the enrollment id and a link to the enrollment request
 	 *
-	 * @param array $_product Product object.
+	 * @param array $product Product object.
 	 * @param array $item Order item.
 	 * @param int   $item_id Order item id.
 	 *
 	 * @return void
 	 */
-	public function add_admin_order_item_values( $_product, $item, $item_id = null ) {
+	public function add_admin_order_item_values( $product, $item, $item_id = null ) {
 
 		// Check if the product has a non-empty "_course_id" metadata.
-		$_course_id = '';
+		$course_id = '';
 
-		if ( $_product ) {
-			$_course_id = get_post_meta( $_product->get_id(), '_course_id', true );
+		if ( $product ) {
+			$course_id = get_post_meta( $product->get_id(), '_course_id', true );
 		}
 
-		if ( ! empty( $_course_id ) ) {
+		if ( ! empty( $course_id ) ) {
 
 			$order_id    = method_exists( $item, 'get_order_id' ) ? $item->get_order_id() : $item['order_id'];
 			$input_value = get_post_meta( $order_id, 'enrollment_id' . $item_id, true );

--- a/includes/class-openedx-woocommerce-plugin.php
+++ b/includes/class-openedx-woocommerce-plugin.php
@@ -244,6 +244,7 @@ class Openedx_Woocommerce_Plugin {
 		);
 
 		$this->loader->add_action( 'woocommerce_order_status_changed', $plugin_admin, 'process_order_data', 10, 2 );
+		$this->loader->add_action( 'woocommerce_order_refunded', $plugin_admin, 'unenroll_course_refund', 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This feature enables the operator, when processing a refund for a course product, to automatically generate an 'un-enroll' request within the Open edX platform, thus streamlining and expediting the process. Furthermore, the operator will have access to corresponding logs indicating whether the process was successful or not, along with links to the new request.

## Testing instructions

To test this, you should navigate to an order and create it either manually or using the existing PayPal process to generate a new order. Once the order status is 'processing,' click on the 'refund' button, select the amount, and click 'accept.' Subsequently, the entire process will appear in the order notes, and the associated Enrollment Request ID will be updated.

This is how the refund looks like: 
![image](https://github.com/eduNEXT/openedx-woocommerce-plugin/assets/52968528/4d6a912c-29cf-44c0-98da-81112de9a50f)


## Additional information

This process only covers the happy path, meaning that more complicated error cases, such as edge cases, may cause the process to fail or trigger a fatal WordPress error.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits
