### PR TITLE
fix: bugs in product table fixed & form changes in settings and enrollment

### DIFF
--- a/admin/class-openedx-woocommerce-plugin-admin.php
+++ b/admin/class-openedx-woocommerce-plugin-admin.php
@@ -304,6 +304,18 @@ class Openedx_Woocommerce_Plugin_Admin {
 					'td'    => array(),
 				)
 			);
+		} else {
+
+			$html_output  = '<td>';
+			$html_output .= esc_html__( 'Product is not an Open edX Course', 'woocommerce' );
+			$html_output .= '</td>';
+
+			echo wp_kses(
+				$html_output,
+				array(
+					'td' => array(),
+				)
+			);
 		}
 	}
 

--- a/admin/views/class-openedx-woocommerce-plugin-enrollment-info-form.php
+++ b/admin/views/class-openedx-woocommerce-plugin-enrollment-info-form.php
@@ -200,10 +200,14 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
 							<td class="checkbox-td">		
 								<input class="action-checkbox" type="checkbox" id="force" name="enrollment_force" value="opcion1">
 								<label for="force"><?php esc_html_e( 'Use the "force" flag', 'wp-openedx-woocommerce-plugin' ); ?></label>
+								<span class="tooltip-icon">?</span>
+								<span class="tooltip-text"><?php esc_html_e( 'Lorem ipsum.', 'wp-openedx-woocommerce-plugin' ); ?></span>
 							</td>
 							<td>
 								<input class="action-checkbox" type="checkbox" id="no_pre" name="enrollment_allowed" value="opcion1">
 								<label for="no_pre"><?php esc_html_e( "Create course enrollment allowed if the user doesn't exist", 'wp-openedx-woocommerce-plugin' ); ?></label>
+								<span class="tooltip-icon">?</span>
+								<span class="tooltip-text"><?php esc_html_e( 'Lorem ipsum.', 'wp-openedx-woocommerce-plugin' ); ?></span>
 							</td>
 						</tr>
 

--- a/admin/views/class-openedx-woocommerce-plugin-settings.php
+++ b/admin/views/class-openedx-woocommerce-plugin-settings.php
@@ -255,7 +255,7 @@ class Openedx_Woocommerce_Plugin_Settings {
 		$value = get_option( 'openedx-client-secret' );
 		?>
 
-		<input class="setting_input" type="text" name="openedx-client-secret" id="openedx-client-secret" 
+		<input class="setting_input" type="password" name="openedx-client-secret" id="openedx-client-secret" 
 			value="<?php echo esc_attr( $value ); ?>" required />
 
 		<p class="description">


### PR DESCRIPTION
## Description

Some issues that were occurring in the order when adding more products have been resolved, where the product table was experiencing visual glitches. Additionally, some modifications have been made to the CSS of the forms in the settings. The 'client secret' field now has its value hidden, and tooltips have been added to the checkboxes in the enrollment form.

## Additional information

An important point to mention is that, in this case, it's preferable to keep the Client Secret as a 'password' and not display characters initially for security reasons (even though the token, being lengthy, adds a layer of security). It's better to keep it hidden. Another reason is to avoid having to insert JavaScript code because with HTML, it becomes complex to have a visible field for the user with a value like 'ABCD***HIJK' without modifying the form's behavior. This is because there needs to be both a hidden input and a visible input, which can potentially lead to conflicts when modifying the value.

This is what an order with more than one product looks like:
![image](https://github.com/eduNEXT/openedx-woocommerce-plugin/assets/52968528/aa1bbc5d-5f49-4705-9666-e12897433aa2)

This is how the Client Secret is being displayed:

![image](https://github.com/eduNEXT/openedx-woocommerce-plugin/assets/52968528/d2ce753a-d72f-4aa3-9a30-bf0e80fc4f92)

These are the tooltips for checkboxes in the Enrollment form:

![image](https://github.com/eduNEXT/openedx-woocommerce-plugin/assets/52968528/da694a02-913d-460f-9ca6-228c6e50e428)


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits