### PR TITLE
feat: enroll and unenroll process with new and old endpoints

### DIFF
--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -132,13 +132,13 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		$status_code  = '';
 
 		if ( 'error' === $response_new[0] ) {
-			$status_code = strval($response_new[2]);
+			$status_code = strval( $response_new[2] );
 		}
-		
-		if ( 'enrollment_allowed' === $enrollment_action && '409' === $status_code ) {
-			
+
+		if ( ( 'enrollment_allowed' === $enrollment_action || 'enrollment_allowed_force' === $enrollment_action ) && '409' === $status_code ) {
+
 			return $response_new;
-		} else {
+		} elseif ( ( 'enrollment_allowed' !== $enrollment_action || 'enrollment_allowed_force' !== $enrollment_action ) && '409' !== $status_code ) {
 			if ( 'success' === $response_new[0] ) {
 				return $response_new;
 			} else {

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -151,14 +151,9 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			return array( 'not_api', 'This action does not require an API call.' );
 		}
 
-		$access_token = $this->check_access_token();
-
-		// The access token can be an array or not; if it's an array, we need the value at index 1, which contains the generated token.
-		if ( 'array' === gettype( $access_token ) ) {
-			$access_token = $access_token[1];
-		}
-
-		$user         = $this->check_if_user_exists( $enrollment_data['enrollment_email'], $access_token );
+		$access_token        = $this->check_access_token();
+		$access_token_string = $this->get_access_token( $access_token );
+		$user                = $this->check_if_user_exists( $enrollment_data['enrollment_email'], $access_token_string );
 
 		$course_id    = $enrollment_data['enrollment_course_id'];
 		$course_mode  = $enrollment_data['enrollment_mode'];
@@ -183,11 +178,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					),
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return $this->enrollment_allowed_checks( $enrollment_data, $access_token );
+				return $this->enrollment_allowed_checks( $enrollment_data, $access_token_string );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -207,11 +202,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					'force_enrollment'      => true,
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return $this->enrollment_allowed_checks( $enrollment_data, $access_token, true );
+				return $this->enrollment_allowed_checks( $enrollment_data, $access_token_string, true );
 			}
 		} elseif ( 'unenroll' === $request_type ) {
 
@@ -233,11 +228,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					'is_active'             => false,
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token );
+				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token_string );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -258,11 +253,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					'is_active'             => false,
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token, true );
+				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token_string, true );
 
 			}
 		}
@@ -275,7 +270,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				'course_id' => str_replace( '+', '%2B', $course_id ),
 			);
 
-			return $this->enrollment_sync_request( $method, $body, $access_token );
+			return $this->enrollment_sync_request( $method, $body, $access_token_string );
 		}
 	}
 
@@ -288,7 +283,9 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 */
 	public function enrollment_send_request_new_endpoints( $enrollment_data, $enrollment_action ) {
 
-		$access_token     = $this->check_access_token();
+		$access_token        = $this->check_access_token();
+		$access_token_string = $this->get_access_token( $access_token );
+
 		$course_id        = $enrollment_data['enrollment_course_id'];
 		$course_mode      = $enrollment_data['enrollment_mode'];
 		$request_type     = $enrollment_data['enrollment_request_type'];
@@ -314,11 +311,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					),
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return $this->enrollment_allowed_checks( $enrollment_data, $access_token );
+				return $this->enrollment_allowed_checks( $enrollment_data, $access_token_string );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -338,11 +335,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					'force_enrollment'      => true,
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return $this->enrollment_allowed_checks( $enrollment_data, $access_token, true );
+				return $this->enrollment_allowed_checks( $enrollment_data, $access_token_string, true );
 			}
 		} elseif ( 'unenroll' === $request_type ) {
 
@@ -364,11 +361,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					'is_active'             => false,
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token );
+				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token_string );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -389,11 +386,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 					'is_active'             => false,
 				);
 
-				return $this->enrollment_request_api_call( $method, $body, $access_token );
+				return $this->enrollment_request_api_call( $method, $body, $access_token_string );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token, true );
+				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token_string, true );
 			}
 		}
 
@@ -405,7 +402,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				'course_id' => str_replace( '+', '%2B', $course_id ),
 			);
 
-			return $this->enrollment_sync_request( $method, $body, $access_token );
+			return $this->enrollment_sync_request( $method, $body, $access_token_string );
 		}
 	}
 
@@ -413,15 +410,15 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 * Create the request to the new endpoint for enrollment allowed.
 	 *
 	 * @param string $enrollment_data The enrollment data.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 * @param string $force If the request is forced or not.
 	 * @return array The response array.
 	 */
-	public function enrollment_allowed_checks( $enrollment_data, $access_token, $force = false ) {
+	public function enrollment_allowed_checks( $enrollment_data, $access_token_string, $force = false ) {
 
 		$course_id        = $enrollment_data['enrollment_course_id'];
 		$enrollment_email = $enrollment_data['enrollment_email'];
-		$user_exist       = $this->check_if_user_exists( $enrollment_email, $access_token );
+		$user_exist       = $this->check_if_user_exists( $enrollment_email, $access_token_string );
 
 		if ( 'success' !== $user_exist[0] ) {
 
@@ -442,7 +439,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				);
 			}
 
-			return $this->enrollment_allowed_request( $method, $body, $access_token );
+			return $this->enrollment_allowed_request( $method, $body, $access_token_string );
 
 		} else {
 
@@ -455,14 +452,14 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 * Create the request to the new endpoint for unenrollment with enrollment_allowed enabled.
 	 *
 	 * @param string $enrollment_data The enrollment data.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 * @param string $force If the request is forced or not.
 	 */
-	public function unenrollment_allowed_checks( $enrollment_data, $access_token, $force = false ) {
+	public function unenrollment_allowed_checks( $enrollment_data, $access_token_string, $force = false ) {
 
 		$course_id        = $enrollment_data['enrollment_course_id'];
 		$enrollment_email = $enrollment_data['enrollment_email'];
-		$user_exist       = $this->check_if_user_exists( $enrollment_email, $access_token );
+		$user_exist       = $this->check_if_user_exists( $enrollment_email, $access_token_string );
 
 		if ( 'success' !== $user_exist[0] ) {
 
@@ -481,7 +478,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				);
 			}
 
-			$response = $this->enrollment_allowed_request( $method, $body, $access_token );
+			$response = $this->enrollment_allowed_request( $method, $body, $access_token_string );
 
 			if ( 'success' === $response[0] ) {
 				return array( 'success', wp_json_encode( 'User unenrolled successfully.' ) );
@@ -499,12 +496,12 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 * Check if a user exists in the Open edX platform using its email.
 	 *
 	 * @param string $enrollment_email The user email.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 * @return array The response array.
 	 */
-	public function check_if_user_exists( $enrollment_email, $access_token ) {
+	public function check_if_user_exists( $enrollment_email, $access_token_string ) {
 
-		$user = $this->get_user( $enrollment_email, $access_token );
+		$user = $this->get_user( $enrollment_email, $access_token_string );
 		return $user;
 	}
 
@@ -513,10 +510,10 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 *
 	 * @param string $method The HTTP method to use.
 	 * @param array  $body The request body.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 * @return array The response array.
 	 */
-	public function enrollment_allowed_request( $method, $body, $access_token ) {
+	public function enrollment_allowed_request( $method, $body, $access_token_string ) {
 
 		$domain = get_option( 'openedx-domain' );
 
@@ -527,7 +524,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				$domain . self::API_ENROLLMENT_ALLOWED,
 				array(
 					'headers' => array(
-						'Authorization' => 'JWT ' . $access_token,
+						'Authorization' => 'JWT ' . $access_token_string,
 						'Content-Type'  => 'application/json',
 					),
 					'json'    => $body,
@@ -549,11 +546,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 *
 	 * @param string $method The HTTP method to use.
 	 * @param array  $body The request body.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 *
 	 * @return array The response array.
 	 */
-	public function enrollment_request_api_call( $method, $body, $access_token ) {
+	public function enrollment_request_api_call( $method, $body, $access_token_string ) {
 
 		$domain = get_option( 'openedx-domain' );
 
@@ -564,7 +561,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				$domain . self::API_ENROLLMENT,
 				array(
 					'headers' => array(
-						'Authorization' => 'JWT ' . $access_token,
+						'Authorization' => 'JWT ' . $access_token_string,
 						'Content-Type'  => 'application/json',
 					),
 					'json'    => $body,
@@ -573,7 +570,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			$status_code   = $response->getStatusCode();
 			$response_data = $response->getBody();
-			return array( 'success', $status_code . ': ' . $response_data );
+			return array( 'success', $response_data );
 		} catch ( RequestException $e ) {
 			return $this->handle_request_error( $e );
 		} catch ( GuzzleException $e ) {
@@ -586,11 +583,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 *
 	 * @param string $method The HTTP method to use.
 	 * @param array  $body The request body.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 *
 	 * @return array The response array.
 	 */
-	public function enrollment_sync_request( $method, $body, $access_token ) {
+	public function enrollment_sync_request( $method, $body, $access_token_string ) {
 
 		$domain = get_option( 'openedx-domain' );
 		$url    = $domain . self::API_SYNC_ENROLLMENT . '?username=' . $body['username'] . '&course_id=' . $body['course_id'];
@@ -602,7 +599,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				$url,
 				array(
 					'headers' => array(
-						'Authorization' => 'JWT ' . $access_token,
+						'Authorization' => 'JWT ' . $access_token_string,
 						'Content-Type'  => 'application/json',
 					),
 				),
@@ -671,11 +668,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 * Send a request to get the username based on the provided user email.
 	 *
 	 * @param string $email The user email.
-	 * @param string $access_token The access token.
+	 * @param string $access_token_string The access token.
 	 *
 	 * @return string|array The username string, or an error array.
 	 */
-	public function get_user( $email, $access_token ) {
+	public function get_user( $email, $access_token_string ) {
 
 		$domain = get_option( 'openedx-domain' );
 
@@ -685,7 +682,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				$domain . self::API_GET_USER,
 				array(
 					'headers' => array(
-						'Authorization' => 'JWT ' . $access_token,
+						'Authorization' => 'JWT ' . $access_token_string,
 					),
 					'query'   => array(
 						'email' => $email,
@@ -701,6 +698,21 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			return $this->handle_request_error( $e );
 		} catch ( GuzzleException $e ) {
 			return array( 'error', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * // The access token can be an array or not; if it's an array, we need the value at index 1, which contains the generated token.
+	 *
+	 * @param string $access_token_string The access token.
+	 * @return string The access token string.
+	 */
+	public function get_access_token( $access_token_string ) {
+
+		if ( 'array' === gettype( $access_token_string ) ) {
+			return $access_token_string[1];
+		} else {
+			return $access_token_string;
 		}
 	}
 }

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -36,7 +36,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	const API_GET_USER        = '/api/user/v1/accounts';
 
 	// API constants for new endpoints available for Open edX API calls.
-	const API_ENROLLMENT_ALLOWED = '/api/enrollment/v1/enrollment_allowed/';
+	const API_ENROLLMENT_ALLOWED      = '/api/enrollment/v1/enrollment_allowed/';
 	const API_ENROLLMENT_ALLOWED_SYNC = '/api/enrollment/v1/enrollment_allowed';
 
 	/**
@@ -117,6 +117,15 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		}
 	}
 
+	/**
+	 * Decide how the process has to do the API request depending on the new endpoints response.
+	 * If the response works, it will return the response, if not, it will try and return the
+	 * old endpoints response.
+	 *
+	 * @param string $enrollment_data The enrollment data.
+	 * @param string $enrollment_action The enrollment action.
+	 * @return array The response array.
+	 */
 	public function enrollment_handle_old_or_new( $enrollment_data, $enrollment_action ) {
 
 		$response_new = $this->enrollment_send_request_new_endpoints( $enrollment_data, $enrollment_action );
@@ -177,7 +186,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				return $this->enrollment_request_api_call( $method, $body, $access_token );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
-				
+
 				return $this->enrollment_allowed_checks( $enrollment_data, $access_token );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
@@ -201,7 +210,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				return $this->enrollment_request_api_call( $method, $body, $access_token );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
-				
+
 				return $this->enrollment_allowed_checks( $enrollment_data, $access_token, true );
 			}
 		} elseif ( 'unenroll' === $request_type ) {
@@ -227,7 +236,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				return $this->enrollment_request_api_call( $method, $body, $access_token );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
-				
+
 				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
@@ -252,7 +261,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				return $this->enrollment_request_api_call( $method, $body, $access_token );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
-				
+
 				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token, true );
 
 			}
@@ -270,6 +279,13 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		}
 	}
 
+	/**
+	 * Send the enroll and unenroll requests to the new endpoints using directly the user email.
+	 *
+	 * @param string $enrollment_data The enrollment data.
+	 * @param string $enrollment_action The enrollment action.
+	 * @return array The response array.
+	 */
 	public function enrollment_send_request_new_endpoints( $enrollment_data, $enrollment_action ) {
 
 		$access_token     = $this->check_access_token();
@@ -325,11 +341,9 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				return $this->enrollment_request_api_call( $method, $body, $access_token );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
-		
+
 				return $this->enrollment_allowed_checks( $enrollment_data, $access_token, true );
-
 			}
-
 		} elseif ( 'unenroll' === $request_type ) {
 
 			if ( 'enrollment_process' === $enrollment_action ) {
@@ -378,9 +392,8 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				return $this->enrollment_request_api_call( $method, $body, $access_token );
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
-				
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token, true );
 
+				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token, true );
 			}
 		}
 
@@ -396,28 +409,36 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		}
 	}
 
+	/**
+	 * Create the request to the new endpoint for enrollment allowed.
+	 *
+	 * @param string $enrollment_data The enrollment data.
+	 * @param string $access_token The access token.
+	 * @param string $force If the request is forced or not.
+	 * @return array The response array.
+	 */
 	public function enrollment_allowed_checks( $enrollment_data, $access_token, $force = false ) {
 
 		$course_id        = $enrollment_data['enrollment_course_id'];
 		$enrollment_email = $enrollment_data['enrollment_email'];
-		$user_exist = $this->check_if_user_exists( $enrollment_email, $access_token );
+		$user_exist       = $this->check_if_user_exists( $enrollment_email, $access_token );
 
 		if ( 'success' !== $user_exist[0] ) {
 
 			$method = 'POST';
 
-			if ( !$force ) {
-				$body   = array(
+			if ( ! $force ) {
+				$body = array(
 					'email'       => $enrollment_email,
 					'course_id'   => $course_id,
 					'auto_enroll' => true,
 				);
 			} else {
-				$body   = array(
-					'email'       => $enrollment_email,
-					'course_id'   => $course_id,
-					'auto_enroll' => true,
-					'force_enrollment'      => true,
+				$body = array(
+					'email'            => $enrollment_email,
+					'course_id'        => $course_id,
+					'auto_enroll'      => true,
+					'force_enrollment' => true,
 				);
 			}
 
@@ -428,55 +449,73 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			return $this->enrollment_handle_old_or_new( $enrollment_data, 'enrollment_process' );
 
 		}
-
 	}
 
+	/**
+	 * Create the request to the new endpoint for unenrollment with enrollment_allowed enabled.
+	 *
+	 * @param string $enrollment_data The enrollment data.
+	 * @param string $access_token The access token.
+	 * @param string $force If the request is forced or not.
+	 */
 	public function unenrollment_allowed_checks( $enrollment_data, $access_token, $force = false ) {
 
 		$course_id        = $enrollment_data['enrollment_course_id'];
 		$enrollment_email = $enrollment_data['enrollment_email'];
-		$user_exist = $this->check_if_user_exists( $enrollment_email, $access_token );
-		$enrollment_allowed_exist = false;
+		$user_exist       = $this->check_if_user_exists( $enrollment_email, $access_token );
 
 		if ( 'success' !== $user_exist[0] ) {
 
 			$method = 'DELETE';
 
-			if ( !$force ) {
-				$body   = array(
-					'email'       => $enrollment_email,
-					'course_id'   => $course_id,
+			if ( ! $force ) {
+				$body = array(
+					'email'     => $enrollment_email,
+					'course_id' => $course_id,
 				);
 			} else {
-				$body   = array(
-					'email'       => $enrollment_email,
-					'course_id'   => $course_id,
-					'force_enrollment'      => true,
+				$body = array(
+					'email'            => $enrollment_email,
+					'course_id'        => $course_id,
+					'force_enrollment' => true,
 				);
 			}
 
 			$response = $this->enrollment_allowed_request( $method, $body, $access_token );
-			if ( 'success' == $response[0] ) {
-				return array( 'success', json_encode( 'User unenrolled successfully.' ) );
+
+			if ( 'success' === $response[0] ) {
+				return array( 'success', wp_json_encode( 'User unenrolled successfully.' ) );
 			} else {
 				return $response;
 			}
-
 		} else {
 
 			return $this->enrollment_handle_old_or_new( $enrollment_data, 'enrollment_process' );
 
 		}
-
 	}
 
+	/**
+	 * Check if a user exists in the Open edX platform using its email.
+	 *
+	 * @param string $enrollment_email The user email.
+	 * @param string $access_token The access token.
+	 * @return array The response array.
+	 */
 	public function check_if_user_exists( $enrollment_email, $access_token ) {
 
 		$user = $this->get_user( $enrollment_email, $access_token );
 		return $user;
-
 	}
 
+	/**
+	 * Performs a request to the enrollment_allowed Open edX API endpoint.
+	 *
+	 * @param string $method The HTTP method to use.
+	 * @param array  $body The request body.
+	 * @param string $access_token The access token.
+	 * @return array The response array.
+	 */
 	public function enrollment_allowed_request( $method, $body, $access_token ) {
 
 		$domain = get_option( 'openedx-domain' );
@@ -534,7 +573,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			$status_code   = $response->getStatusCode();
 			$response_data = $response->getBody();
-			return array( 'success', $status_code . ": " . $response_data );
+			return array( 'success', $status_code . ': ' . $response_data );
 		} catch ( RequestException $e ) {
 			return $this->handle_request_error( $e );
 		} catch ( GuzzleException $e ) {

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -231,7 +231,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
+				return array( 'error', 'The creation of course enrollment allowed is only supported by Open edX versions equal to or higher than Quince.' );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -255,7 +255,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
+				return array( 'error', 'The creation of course enrollment allowed is only supported by Open edX versions equal to or higher than Quince.' );
 			}
 		} elseif ( 'unenroll' === $request_type ) {
 
@@ -281,7 +281,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
+				return array( 'error', 'The creation of course enrollment allowed is only supported by Open edX versions equal to or higher than Quince.' );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -306,7 +306,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
+				return array( 'error', 'The creation of course enrollment allowed is only supported by Open edX versions equal to or higher than Quince.' );
 
 			}
 		}

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -108,9 +108,9 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			$error_data  = $e->getResponse()->getBody()->getContents();
 
 			if ( isset( json_decode( $error_data, true )['error'] ) ) {
-				return array( 'error', $status_code . ': ' . json_decode( $error_data, true )['error'] );
+				return array( 'error', $status_code . ': ' . json_decode( $error_data, true )['error'], $status_code );
 			} elseif ( isset( json_decode( $error_data, true )['message'] ) ) {
-				return array( 'error', $status_code . ': ' . json_decode( $error_data, true )['message'] );
+				return array( 'error', $status_code . ': ' . json_decode( $error_data, true )['message'], $status_code );
 			} else {
 				return array( 'error', $status_code . ': ' . $e->getMessage() );
 			}
@@ -129,11 +129,21 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	public function enrollment_handle_old_or_new( $enrollment_data, $enrollment_action ) {
 
 		$response_new = $this->enrollment_send_request_new_endpoints( $enrollment_data, $enrollment_action );
+		$status_code  = '';
 
-		if ( 'success' === $response_new[0] ) {
+		if ( 'error' === $response_new[0] ) {
+			$status_code = strval($response_new[2]);
+		}
+		
+		if ( 'enrollment_allowed' === $enrollment_action && '409' === $status_code ) {
+			
 			return $response_new;
 		} else {
-			return $this->enrollment_send_request( $enrollment_data, $enrollment_action );
+			if ( 'success' === $response_new[0] ) {
+				return $response_new;
+			} else {
+				return $this->enrollment_send_request( $enrollment_data, $enrollment_action );
+			}
 		}
 	}
 

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -182,7 +182,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return $this->enrollment_allowed_checks( $enrollment_data, $access_token_string );
+				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -206,7 +206,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return $this->enrollment_allowed_checks( $enrollment_data, $access_token_string, true );
+				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
 			}
 		} elseif ( 'unenroll' === $request_type ) {
 
@@ -232,7 +232,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
 
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token_string );
+				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
 
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 				$method = 'POST';
@@ -257,7 +257,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
-				return $this->unenrollment_allowed_checks( $enrollment_data, $access_token_string, true );
+				return array( 'error', 'This feature is only supported by Open edX versions equal to or higher than Quince.' );
 
 			}
 		}
@@ -270,7 +270,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				'course_id' => str_replace( '+', '%2B', $course_id ),
 			);
 
-			return $this->enrollment_sync_request( $method, $body, $access_token_string );
+			return $this->enrollment_sync_request( $method, $body, $access_token_string, 'username' );
 		}
 	}
 
@@ -403,11 +403,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			$method = 'GET';
 			$body   = array(
-				'username'  => $user[1],
+				'email'  => $enrollment_email,
 				'course_id' => str_replace( '+', '%2B', $course_id ),
 			);
 
-			return $this->enrollment_sync_request( $method, $body, $access_token_string );
+			return $this->enrollment_sync_request( $method, $body, $access_token_string, 'email' );
 		}
 	}
 
@@ -589,13 +589,14 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 * @param string $method The HTTP method to use.
 	 * @param array  $body The request body.
 	 * @param string $access_token_string The access token.
+	 * @param string $user_filter User filter to know if it's using email or username.
 	 *
 	 * @return array The response array.
 	 */
-	public function enrollment_sync_request( $method, $body, $access_token_string ) {
+	public function enrollment_sync_request( $method, $body, $access_token_string, $user_filter ) {
 
 		$domain = get_option( 'openedx-domain' );
-		$url    = $domain . self::API_SYNC_ENROLLMENT . '?username=' . $body['username'] . '&course_id=' . $body['course_id'];
+		$url    = $domain . self::API_SYNC_ENROLLMENT . '?' . $user_filter . '=' . $body[$user_filter] . '&course_id=' . $body['course_id'];
 
 		try {
 

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -200,6 +200,10 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		$access_token_string = $this->get_access_token( $access_token );
 		$user                = $this->check_if_user_exists( $enrollment_data['enrollment_email'], $access_token_string );
 
+		if ( 'error' === $user[0] ) {
+			return $user;
+		}
+
 		$course_id    = $enrollment_data['enrollment_course_id'];
 		$course_mode  = $enrollment_data['enrollment_mode'];
 		$request_type = $enrollment_data['enrollment_request_type'];

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -283,6 +283,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	 */
 	public function enrollment_send_request_new_endpoints( $enrollment_data, $enrollment_action ) {
 
+		if ( 'save_no_process' === $enrollment_action ) {
+
+			return array( 'not_api', 'This action does not require an API call.' );
+		}
+
 		$access_token        = $this->check_access_token();
 		$access_token_string = $this->get_access_token( $access_token );
 

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -403,7 +403,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			$method = 'GET';
 			$body   = array(
-				'email'  => $enrollment_email,
+				'email'     => $enrollment_email,
 				'course_id' => str_replace( '+', '%2B', $course_id ),
 			);
 
@@ -596,7 +596,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 	public function enrollment_sync_request( $method, $body, $access_token_string, $user_filter ) {
 
 		$domain = get_option( 'openedx-domain' );
-		$url    = $domain . self::API_SYNC_ENROLLMENT . '?' . $user_filter . '=' . $body[$user_filter] . '&course_id=' . $body['course_id'];
+		$url    = $domain . self::API_SYNC_ENROLLMENT . '?' . $user_filter . '=' . $body[ $user_filter ] . '&course_id=' . $body['course_id'];
 
 		try {
 

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -341,7 +341,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 		}
 
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
-		$enrollment_api_response = $api->enrollment_handle_old_or_new( $enrollment_data, $enrollment_action );
+		$enrollment_api_response = $api->request_handler( $enrollment_data, $enrollment_action );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
 
 		if ( null !== $order_id ) {

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -341,7 +341,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 		}
 
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
-		$enrollment_api_response = $api->enrollment_send_request( $enrollment_data, $enrollment_action );
+		$enrollment_api_response = $api->enrollment_handle_old_or_new( $enrollment_data, $enrollment_action );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
 
 		if ( null !== $order_id ) {


### PR DESCRIPTION
## Description

A dynamic approach is implemented between the new endpoints for enrollments and unenrollments and the 'legacy' endpoints that have been functioning currently. The goal is to foster versatility across platforms, allowing both new and existing systems to seamlessly utilize these changes. This transition ensures a progressive and secure adoption of the new implementations across various platforms.

To achieve this, an attempt is made to execute processes using the new endpoints. In case of failure, a fallback to the 'legacy' endpoints is initiated. If the response is positive in the first attempt, the response is returned directly.

Additionally, a minor issue has been addressed where error messages from the API were not displayed as-is but were briefly processed, resulting in limited visibility of the actual error feedback.

## Testing instructions

Go to the stage and create or update enrollments, you can also try the enrollment allowed process. The new features have already been uploaded to the stage.

## Additional information

The default answer for an unenrollment with enrollment__allowed is "[]". A custom message for it was implemented to give enough feedback to the user to know if the process response was good. The message is "User unenrolled successfully".
