### PR TITLE
fix: access token doesn't generate errors when token expires

### DIFF
--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -128,6 +128,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 		$access_token = $this->check_access_token();
 
+		// The access token can be an array or not; if it's an array, we need the value at index 1, which contains the generated token.
 		if ( 'array' === gettype( $access_token ) ) {
 			$access_token = $access_token[1];
 		}

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -127,6 +127,11 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		}
 
 		$access_token = $this->check_access_token();
+
+		if ( 'array' === gettype( $access_token ) ) {
+			$access_token = $access_token[1];
+		}
+
 		$user         = $this->get_user( $enrollment_data['enrollment_email'], $access_token );
 
 		if ( 'error' === $access_token[0] || 'error' === $user[0] ) {

--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -132,7 +132,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			$access_token = $access_token[1];
 		}
 
-		$user         = $this->get_user( $enrollment_data['enrollment_email'], $access_token );
+		$user = $this->get_user( $enrollment_data['enrollment_email'], $access_token );
 
 		if ( 'error' === $access_token[0] || 'error' === $user[0] ) {
 			if ( 'error' === $access_token[0] && 'error' === $user[0] ) {


### PR DESCRIPTION
## Description

There was a bug that caused an error when you tried to make, for the first time after a while, a new request. This request showed something like 'error getting user' and it was not a problem with the get_user function, it was a problem with the access token. The creation of a new token returns an array containing the 'success' message and the token generated by the API but, when the token is available, it returns only the token value because the process sends a request to the WP database. For that, a check for the access token response was added: when the response is an array it takes the value of the token from the array, when it isn't, it continues the process as always. 

## Testing instructions

You can test it by changing the expiration time of the access token and attempting to create a new request after the token has already expired.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits
