### PR TITLE
fix: improve tooltip info, examples in the domain settings and doc about save before generate token

### DIFF
--- a/admin/css/openedx-woocommerce-plugin-admin.css
+++ b/admin/css/openedx-woocommerce-plugin-admin.css
@@ -108,10 +108,13 @@
     color: white;
     font-size: bold;
     border-radius: 5px;
+    width: 250px;
+    position: absolute;
+    margin-left: 5px;
 }
 
 .tooltip-icon:hover + .tooltip-text {
-    display: unset;
+    display: inline-block;
 }
 
 .setting_input {

--- a/admin/views/class-openedx-woocommerce-plugin-enrollment-info-form.php
+++ b/admin/views/class-openedx-woocommerce-plugin-enrollment-info-form.php
@@ -201,13 +201,13 @@ class Openedx_Woocommerce_Plugin_Enrollment_Info_Form {
 								<input class="action-checkbox" type="checkbox" id="force" name="enrollment_force" value="opcion1">
 								<label for="force"><?php esc_html_e( 'Use the "force" flag', 'wp-openedx-woocommerce-plugin' ); ?></label>
 								<span class="tooltip-icon">?</span>
-								<span class="tooltip-text"><?php esc_html_e( 'Lorem ipsum.', 'wp-openedx-woocommerce-plugin' ); ?></span>
+								<span class="tooltip-text"><?php esc_html_e( "Disregard the course's enrollment end dates.", 'wp-openedx-woocommerce-plugin' ); ?></span>
 							</td>
 							<td>
 								<input class="action-checkbox" type="checkbox" id="no_pre" name="enrollment_allowed" value="opcion1">
 								<label for="no_pre"><?php esc_html_e( "Create course enrollment allowed if the user doesn't exist", 'wp-openedx-woocommerce-plugin' ); ?></label>
 								<span class="tooltip-icon">?</span>
-								<span class="tooltip-text"><?php esc_html_e( 'Lorem ipsum.', 'wp-openedx-woocommerce-plugin' ); ?></span>
+								<span class="tooltip-text"><?php esc_html_e( 'Creates a register in the table Course Enrollment Allowed if the email we use in the request is not a user in our Open edX platform yet.', 'wp-openedx-woocommerce-plugin' ); ?></span>
 							</td>
 						</tr>
 

--- a/admin/views/class-openedx-woocommerce-plugin-settings.php
+++ b/admin/views/class-openedx-woocommerce-plugin-settings.php
@@ -218,7 +218,7 @@ class Openedx_Woocommerce_Plugin_Settings {
 		<input class="setting_input" type="text" name="openedx-domain" id="openedx-domain" 
 			value="<?php echo esc_attr( $value ); ?>" required />
 
-		<p class='description'>Your Open edX platform's web address.</p>
+		<p class='description'>Your LMS Open edX platform's web address. e.g. https://lms.nightly.dedalo.edunext.link or http://local.overhang.io:8000</p>
 
 		<?php
 	}
@@ -299,7 +299,7 @@ class Openedx_Woocommerce_Plugin_Settings {
 
 		</div>
 
-		<p class="description"> Select the Generate Token button to obtain a JWT Token. </p>
+		<p class="description"> Select the Generate Token button to obtain a JWT Token. Remember to save your changes before creating the JWT token.</p>
 
 		<?php
 	}


### PR DESCRIPTION
## Description
This PR adds:
- Tooltip info in the enrollment request
- Examples in the Open edX domain in settings
- A note to remember to save before generating token