### PR TITLE
build: use ubuntu-lts-latest in readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ sphinx:
 
 # Set the version of python needed to build these docs.
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-lts-latest"
   tools:
     python: "3.8"
 


### PR DESCRIPTION
- PR created under the [issue](https://github.com/openedx/public-engineering/issues/418) to update the os version in the `readthedocs` build workflow.