### PR TITLE
chore: pin GitHub Actions workflows to full commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Composer dependencies
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
       with:
         composer-options: "--no-dev"
 
@@ -21,14 +21,14 @@ jobs:
         make release
 
     - name: Create a zip file
-      uses: thedoctor0/zip-release@0.7.6
+      uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
       with:
         type: 'zip'
         command: 'cd ./openedx-commerce'
         filename: '../openedx-commerce.zip'
 
     - name: Upload zip to the latest GitHub release
-      uses: xresloader/upload-to-github-release@v1
+      uses: xresloader/upload-to-github-release@7c5757a90c0bcf0c0e1741da8f2abd7b85e675d0 # v1.6.2
       env:
         GITHUB_TOKEN: ${{ secrets.WC_PAT }}
       with:

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: php-actions/composer@v6
+      - uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6.1.2
       
       - name: PHPUnit Tests
         run: vendor/bin/phpunit --bootstrap vendor/autoload.php --configuration test/phpunit.xml --coverage-text

--- a/.github/workflows/wordpress-cs-check.yml
+++ b/.github/workflows/wordpress-cs-check.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # master
         with:
           php-version: 'latest'
           ini-values: memory_limit=1G'
@@ -19,7 +19,7 @@ jobs:
           tools: cs2pr
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v4"
+        uses: "ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27" # v4
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Composer dependencies
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
       with:
         composer-options: "--no-dev"
 
@@ -20,6 +20,6 @@ jobs:
         make release
 
     - name: Run plugin check
-      uses: wordpress/plugin-check-action@v1
+      uses: wordpress/plugin-check-action@18573eb38f13543484a1f095672dae3849a4fbb0 # v1.1.6
       with:
         build-dir: './openedx-commerce'


### PR DESCRIPTION
Pins all `uses:` action refs to their full commit SHA with the version tag preserved as a comment. Part of org-wide SHA-pinning migration: openedx/.github#165